### PR TITLE
Bugfix: Config parsed incorrectly

### DIFF
--- a/virage/src/main/java/edu/kit/kastel/formal/util/StringUtils.java
+++ b/virage/src/main/java/edu/kit/kastel/formal/util/StringUtils.java
@@ -42,7 +42,7 @@ public class StringUtils {
      * @return the stripped command String
      */
     public static String strip(final String command) {
-        return command.replaceAll("[;&;|`]*", "");
+        return command.replaceAll("[;&|`]*", "");
     }
 
     /**

--- a/virage/src/main/java/edu/kit/kastel/formal/util/StringUtils.java
+++ b/virage/src/main/java/edu/kit/kastel/formal/util/StringUtils.java
@@ -42,7 +42,7 @@ public class StringUtils {
      * @return the stripped command String
      */
     public static String strip(final String command) {
-        return command.replaceAll("[;&amp;|`]*", "");
+        return command.replaceAll("[;&;|`]*", "");
     }
 
     /**


### PR DESCRIPTION
The commands for external dependencies were not parsed correctly from the virage settings file. The execption occured when isabelle was parsed to isbelle. The cause was an incorrect RegEx in the StringUtils class
![Regex mismatch](https://github.com/VeriVote/ViRAGe/assets/15802245/386dc631-e19c-4104-bd31-3704fce5fee8)
